### PR TITLE
refactor: Troca versao do junit para 4.12 e ajustas as configuracoes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,7 @@ jobs:
   - stage: coverage
     script:
     - "./gradlew jacocoTestReport"
-    - bash <(curl -s https://codecov.io/bash)
-    - java -cp ~/codacy-coverage-reporter-assembly-latest.jar com.codacy.CodacyCoverageReporter -l Java -r build/reports/jacoco/report.xml
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+  - java -cp ~/codacy-coverage-reporter-assembly-latest.jar com.codacy.CodacyCoverageReporter -l Java -r build/reports/jacoco/report.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ branches:
 
 stages:
   - compile
-  - linter
+  - code-quality
   - test
   - integrationTest
+  - coverage
 
 jobs:
   include:
@@ -32,16 +33,21 @@ jobs:
     script:
     - "./gradlew compileKotlin"
 
-  - stage: linter
+  - stage: code-quality
     script:
     - "./gradlew detektFormat"
+    - "./gradlew findbugsMain"
+
+  - stage: test
+    script:
+    - "./gradlew test"
 
   - stage: integrationTest
     script:
     - "./gradlew integrationTest"
 
-  - stage: test
+  - stage: coverage
     script:
-    - "./gradlew junitPlatformJacocoReport"
+    - "./gradlew jacocoTestReport"
     - bash <(curl -s https://codecov.io/bash)
     - java -cp ~/codacy-coverage-reporter-assembly-latest.jar com.codacy.CodacyCoverageReporter -l Java -r build/reports/jacoco/report.xml

--- a/build.gradle
+++ b/build.gradle
@@ -84,10 +84,10 @@ apply from: "${rootProject.rootDir}/gradle/kotlin.gradle"
 apply from: "${rootProject.rootDir}/gradle/linter.gradle"
 apply from: "${rootProject.rootDir}/gradle/jdepend.gradle"
 apply from: "${rootProject.rootDir}/gradle/findbugs.gradle"
-apply from: "${rootProject.rootDir}/gradle/coverage.gradle"
 apply from: "${rootProject.rootDir}/gradle/unit-test.gradle"
 apply from: "${rootProject.rootDir}/gradle/build-scan.gradle"
 apply from: "${rootProject.rootDir}/gradle/integration-test.gradle"
+apply from: "${rootProject.rootDir}/gradle/coverage.gradle"
 
 defaultTasks "clean", "compileKotlin", "detektFormat", "findbugsMain", "test", "integrationTest", "jacocoTestReport",
   "bootJar"

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,6 @@
 buildscript {
   ext {
-    kotlinVersion = "1.1.50"
-    junitGradleVersion = "1.0.0"
-    junitJupiterVerison = "5.0.0"
+    kotlinVersion = "1.1.51"
     springBootVersion = "2.0.0.BUILD-SNAPSHOT"
   }
 
@@ -18,7 +16,6 @@ buildscript {
     classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     classpath "io.spring.gradle:dependency-management-plugin:1.0.3.RELEASE"
-    classpath "org.junit.platform:junit-platform-gradle-plugin:$junitGradleVersion"
     classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
     classpath "gradle.plugin.io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.0.0.RC4-3"
   }
@@ -36,7 +33,6 @@ apply plugin: "org.springframework.boot"
 apply plugin: "org.jetbrains.kotlin.jvm"
 apply plugin: "io.gitlab.arturbosch.detekt"
 apply plugin: "io.spring.dependency-management"
-apply plugin: "org.junit.platform.gradle.plugin"
 
 sourceCompatibility = 1.8
 mainClassName = "br.com.bumblebee.ApplicationKt"
@@ -68,15 +64,14 @@ dependencies {
   compile "org.springframework.cloud:spring-cloud-starter-feign:$springBootVersion"
   compile "org.springframework.cloud:spring-cloud-starter-hystrix:$springBootVersion"
 
+  testCompile "junit:junit:4.12"
   testCompile "org.mockito:mockito-core:2.10.0"
   testCompile "org.jetbrains.kotlin:kotlin-test-junit"
   testCompile "com.nhaarman:mockito-kotlin-kt1.1:1.5.0"
   testCompile "com.jayway.restassured:rest-assured:2.9.0"
   testCompile "org.springframework.boot:spring-boot-starter-test"
-  testCompile "org.junit.jupiter:junit-jupiter-api:$junitJupiterVerison"
   testCompile "de.flapdoodle.embed:de.flapdoodle.embed.mongo:2.0.0"
 
-  testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVerison"
 }
 
 task wrapper(type: Wrapper) {
@@ -85,7 +80,6 @@ task wrapper(type: Wrapper) {
 }
 
 apply from: "${rootProject.rootDir}/gradle/git.gradle"
-apply from: "${rootProject.rootDir}/gradle/junit.gradle"
 apply from: "${rootProject.rootDir}/gradle/kotlin.gradle"
 apply from: "${rootProject.rootDir}/gradle/linter.gradle"
 apply from: "${rootProject.rootDir}/gradle/jdepend.gradle"
@@ -95,4 +89,5 @@ apply from: "${rootProject.rootDir}/gradle/unit-test.gradle"
 apply from: "${rootProject.rootDir}/gradle/build-scan.gradle"
 apply from: "${rootProject.rootDir}/gradle/integration-test.gradle"
 
-defaultTasks "clean", "compileKotlin", "detektFormat", "findbugsMain", "junitPlatformJacocoReport", "bootJar"
+defaultTasks "clean", "compileKotlin", "detektFormat", "findbugsMain", "test", "integrationTest", "jacocoTestReport",
+  "bootJar"

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -1,13 +1,23 @@
-project.afterEvaluate {
-  def junitPlatformTestTask = project.tasks.getByName('junitPlatformTest')
+jacoco {
+  toolVersion = "0.7.9"
+}
 
+test {
   jacoco {
-    toolVersion = "0.7.9"
-    applyTo junitPlatformTestTask
+    append = true
   }
+}
 
-  project.task(type: JacocoReport, "junitPlatformJacocoReport", {
-    dependsOn junitPlatformTestTask
+jacocoTestReport {
+  reports {
+    xml.enabled true
+    html.enabled true
+
+    xml.destination file("${reportsDir}/jacoco/report.xml")
+    html.destination file("${reportsDir}/jacoco/html")
+  }
+  afterEvaluate {
+    executionData test, integrationTest
     sourceDirectories = files("src/main")
     classDirectories = fileTree(
       dir: "${buildDir}/classes/kotlin/main",
@@ -16,15 +26,7 @@ project.afterEvaluate {
         "**/model/**"
       ]
     )
-    executionData junitPlatformTestTask
-
-    reports {
-      xml.enabled true
-      html.enabled true
-
-      xml.destination file("${reportsDir}/jacoco/report.xml")
-      html.destination file("${reportsDir}/jacoco/html")
-    }
-  })
+  }
 }
 
+check.dependsOn jacocoTestReport

--- a/gradle/coverage.gradle
+++ b/gradle/coverage.gradle
@@ -9,6 +9,9 @@ test {
 }
 
 jacocoTestReport {
+  dependsOn test
+  dependsOn integrationTest
+
   reports {
     xml.enabled true
     html.enabled true
@@ -28,5 +31,3 @@ jacocoTestReport {
     )
   }
 }
-
-check.dependsOn jacocoTestReport

--- a/gradle/findbugs.gradle
+++ b/gradle/findbugs.gradle
@@ -1,5 +1,5 @@
 findbugs {
-  ignoreFailures = true
+  ignoreFailures = false
   showProgress = true
 }
 

--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -2,7 +2,7 @@ sourceSets {
   integrationTest {
     compileClasspath += main.output + test.output
     runtimeClasspath += main.output + test.output
-    java.srcDirs = ['src/test/integration/kotlin']
+    kotlin.srcDirs = ['src/test/integration/kotlin']
   }
 }
 
@@ -15,7 +15,9 @@ task integrationTest(type: Test) {
   integrationTest.testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
 
-  reports.html.destination = file("${reporting.baseDir}/${name}")
+  reports {
+    html.destination file("${reporting.baseDir}/tests/integration-test")
+  }
 }
 
 idea {

--- a/gradle/junit.gradle
+++ b/gradle/junit.gradle
@@ -1,7 +1,0 @@
-junitPlatform {
-  filters {
-    engines {
-      include "junit-jupiter"
-    }
-  }
-}

--- a/gradle/unit-test.gradle
+++ b/gradle/unit-test.gradle
@@ -1,5 +1,5 @@
 sourceSets {
   test {
-    java.srcDirs = ['src/test/unit/kotlin']
+    kotlin.srcDirs = ['src/test/unit/kotlin']
   }
 }

--- a/src/test/integration/kotlin/br/com/bumblebee/congressman/repository/ExpenseRepositoryTest.kt
+++ b/src/test/integration/kotlin/br/com/bumblebee/congressman/repository/ExpenseRepositoryTest.kt
@@ -1,28 +1,25 @@
 package br.com.bumblebee.congressman.repository
 
 import br.com.bumblebee.congressman.repository.model.Expense
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.junit4.SpringRunner
+import kotlin.test.assertEquals
 
-
-@ExtendWith(SpringExtension::class)
 @SpringBootTest
+@RunWith(SpringRunner::class)
 internal class ExpenseRepositoryTest {
 
     @Autowired
     private lateinit var repository: ExpenseRepository
 
-    @BeforeEach
+    @Before
     fun setUp() = repository.deleteAll()
 
     @Test
-    @DisplayName("Should save a congressman expense into mongodb")
     fun assertThatExpenseIseBeingSaved() {
         repository.save(Expense("SUPER_COOL_ID"))
         val allExpenses = repository.findAll()

--- a/src/test/unit/kotlin/br/com/bumblebee/ApplicationTest.kt
+++ b/src/test/unit/kotlin/br/com/bumblebee/ApplicationTest.kt
@@ -1,12 +1,12 @@
 package br.com.bumblebee
 
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.Test
+import org.junit.runner.RunWith
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.junit4.SpringRunner
 
 @SpringBootTest
-@ExtendWith(SpringExtension::class)
+@RunWith(SpringRunner::class)
 internal class ApplicationTest {
 
     @Test

--- a/src/test/unit/kotlin/br/com/bumblebee/congressman/controller/CongressmanControllerTest.kt
+++ b/src/test/unit/kotlin/br/com/bumblebee/congressman/controller/CongressmanControllerTest.kt
@@ -5,20 +5,19 @@ import br.com.bumblebee.congressman.client.model.CongressmanClientModel
 import br.com.bumblebee.congressman.client.model.CongressmanClientResponse
 import com.nhaarman.mockito_kotlin.whenever
 import org.hamcrest.Matchers.hasSize
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.Test
+import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
-import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-
-@ExtendWith(SpringExtension::class)
+@RunWith(SpringRunner::class)
 @WebMvcTest(CongressmanController::class)
 internal class CongressmanControllerTest {
 

--- a/src/test/unit/kotlin/br/com/bumblebee/congressman/mapper/CongressmanMapperTest.kt
+++ b/src/test/unit/kotlin/br/com/bumblebee/congressman/mapper/CongressmanMapperTest.kt
@@ -3,7 +3,7 @@ package br.com.bumblebee.congressman.mapper
 import br.com.bumblebee.congressman.client.model.CongressmanClientModel
 import br.com.bumblebee.congressman.client.model.CongressmanClientResponse
 import br.com.bumblebee.congressman.controller.model.CongressmanResponse
-import org.junit.jupiter.api.Test
+import org.junit.Test
 import kotlin.test.assertEquals
 
 internal class CongressmanMapperTest {


### PR DESCRIPTION
1. Utiliza junit 4
2. Atualiza tarefas do CI
3. Atualiza versão do Kotlin
4. Refatora codigo para sintaxe junit 4